### PR TITLE
Include comments in TypeScript definition

### DIFF
--- a/src/TSTypeGen.Tests.Main/TSTypeGen.Tests.Main.csproj
+++ b/src/TSTypeGen.Tests.Main/TSTypeGen.Tests.Main.csproj
@@ -5,6 +5,11 @@
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\TSTypeGen.Tests.Shared\TSTypeGen.Tests.Shared.csproj" />
   </ItemGroup>

--- a/src/TSTypeGen.Tests.Main/can generate comments.cs
+++ b/src/TSTypeGen.Tests.Main/can generate comments.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TSTypeGen.Tests.Shared;
+
+namespace TSTypeGen.Tests.Main
+{
+    /// <typeScriptComment>
+    /// This type is awesome!
+    /// </typeScriptComment>
+    [GenerateTypeScriptDefinition]
+    public abstract class TestClassWithComments
+    {
+        /// <typeScriptComment>
+        /// This is the best property you've ever seen!
+        /// This is a comment on a new line.
+        ///
+        /// Wow, this is a comment with an empty line above it!
+        /// </typeScriptComment>
+        public int Prop1 { get; set; }
+        /// <typeScriptComment>
+        ///
+        /// This comment
+        ///   has a bit
+        ///  odd whitespace
+        ///
+        /// formatting. With whitespace at the end.
+        ///
+        ///
+        /// </typeScriptComment>
+        public int Prop2 { get; set; }
+        /// <summary>
+        /// This is a regular summary comment
+        /// </summary>
+        public int Prop3 { get; set; }
+        /// <summary>
+        /// This is a regular summary comment
+        /// </summary>
+        /// <typeScriptComment>
+        /// This is a typeScriptComment for a property that also has a summary comment
+        /// </typeScriptComment>
+        public int Prop4 { get; set; }
+        /// <summary>
+        /// An empty typeScriptComment prevents this summary from showing up
+        /// </summary>
+        /// <typeScriptComment>
+        /// </typeScriptComment>
+        public int Prop5 { get; set; }
+        public int Prop6 { get; set; }
+    }
+}

--- a/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
+++ b/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
@@ -111,6 +111,40 @@ declare namespace Test {
     prop1: number;
   }
 
+  /**
+   * This type is awesome!
+   */
+  interface TestClassWithComments {
+    /**
+     * This is the best property you've ever seen!
+     * This is a comment on a new line.
+     * 
+     * Wow, this is a comment with an empty line above it!
+     */
+    prop1: number;
+    /**
+     * 
+     * This comment
+     *   has a bit
+     *  odd whitespace
+     * 
+     * formatting. With whitespace at the end.
+     * 
+     * 
+     */
+    prop2: number;
+    /**
+     * This is a regular summary comment
+     */
+    prop3: number;
+    /**
+     * This is a typeScriptComment for a property that also has a summary comment
+     */
+    prop4: number;
+    prop5: number;
+    prop6: number;
+  }
+
   const enum TestConstEnum {
     FirstValue = 'firstValue',
     SecondValue = 'secondValue',

--- a/src/TSTypeGen/AssemblyXmlComments.cs
+++ b/src/TSTypeGen/AssemblyXmlComments.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+
+namespace TSTypeGen
+{
+    public class AssemblyXmlComments
+    {
+        private XmlDocument _document;
+
+        private const string TypeScriptCommentNodeName = "typeScriptComment";
+        private const string SummaryCommentNodeName = "summary";
+
+        public AssemblyXmlComments(string xmlCommentsFilePath)
+        {
+            _document = new XmlDocument();
+            _document.Load(xmlCommentsFilePath);
+        }
+
+        public List<string> GetTypeScriptComment(MemberInfo memberInfo)
+        {
+            var element = GetDocumentation(memberInfo);
+            var typeScriptCommentElement = element?.SelectSingleNode(TypeScriptCommentNodeName) ?? element?.SelectSingleNode(SummaryCommentNodeName);
+            if (string.IsNullOrEmpty(typeScriptCommentElement?.InnerText.Trim()))
+                return null;
+
+            return GetTypeScriptComment(typeScriptCommentElement.InnerText);
+        }
+
+        public List<string> GetTypeScriptComment(Type classOrInterface)
+        {
+            var element = GetDocumentation(classOrInterface);
+            var typeScriptCommentElement = element?.SelectSingleNode(TypeScriptCommentNodeName) ?? element?.SelectSingleNode(SummaryCommentNodeName);
+            if (string.IsNullOrEmpty(typeScriptCommentElement?.InnerText.Trim()))
+            {
+                return null;
+            }
+
+            return GetTypeScriptComment(typeScriptCommentElement.InnerText);
+        }
+
+        private List<string> GetTypeScriptComment(string comment)
+        {
+            comment = Regex.Replace(comment, Environment.NewLine + "$", "");
+            comment = Regex.Replace(comment, "^" + Environment.NewLine, "");
+
+            var result = new List<string>();
+
+            var maxIndentationSize = int.MaxValue;
+
+            using var sr = new StringReader(comment);
+            string line;
+            while ((line = sr.ReadLine()) != null)
+            {
+                if (line.Trim() != string.Empty)
+                {
+                    var indentationSize = 0;
+                    foreach (var chr in line)
+                    {
+                        if (chr == ' ')
+                            indentationSize++;
+                        else
+                            break;
+                    }
+
+                    if (indentationSize < maxIndentationSize)
+                        maxIndentationSize = indentationSize;
+
+                    result.Add(line);
+                }
+                else
+                {
+                    result.Add("");
+                }
+            }
+
+            if (result.Last() == string.Empty)
+            {
+                result.RemoveAt(result.Count - 1);
+            }
+
+            return result.Select(line => Regex.Replace(line, "^" + new string(' ', maxIndentationSize), "")).ToList();
+        }
+
+        private XmlElement GetDocumentation(Type type)
+        {
+            return XmlFromName(type, 'T', "");
+        }
+
+        private XmlElement GetDocumentation(MemberInfo memberInfo)
+        {
+            return XmlFromName(memberInfo.DeclaringType, memberInfo.MemberType.ToString()[0], memberInfo.Name);
+        }
+
+        private XmlElement XmlFromName(Type type, char prefix, string name)
+        {
+            string fullName;
+
+            if (string.IsNullOrEmpty(name))
+                fullName = prefix + ":" + type.FullName;
+            else
+                fullName = prefix + ":" + type.FullName + "." + name;
+
+            var matchedElement = _document["doc"]["members"].SelectSingleNode("member[@name='" + fullName + "']") as XmlElement;
+
+            return matchedElement;
+        }
+    }
+}

--- a/src/TSTypeGen/GeneratedNamespaceFile.cs
+++ b/src/TSTypeGen/GeneratedNamespaceFile.cs
@@ -34,7 +34,7 @@ namespace TSTypeGen
                     innerSource.Append(config.NewLine);
                 }
                 var tsTypeDefinition = await TypeBuilder.BuildTsTypeDefinitionAsync(t, typeBuilderConfig, generatorContext);
-                innerSource.Append(tsTypeDefinition.GetSource(FilePath, config));
+                innerSource.Append(tsTypeDefinition.GetSource(FilePath, config, generatorContext));
                 first = false;
             }
 

--- a/src/TSTypeGen/GeneratorContext.cs
+++ b/src/TSTypeGen/GeneratorContext.cs
@@ -9,11 +9,38 @@ namespace TSTypeGen
     public class GeneratorContext
     {
         public IReadOnlyList<Assembly> Assemblies { get; }
-        public IReadOnlyList<Type> AllTypes => new List<Type>(Assemblies.SelectMany(a => a.GetTypes()));
+        public IReadOnlyList<Type> AllTypes => new List<Type>(Assemblies.SelectMany(t => t.GetTypes()));
 
-        public GeneratorContext(IReadOnlyList<Assembly> assemblies)
+        private IDictionary<Assembly, AssemblyXmlComments> AssemblyComments { get; }
+
+        public GeneratorContext(IReadOnlyList<(Assembly Assembly, string XmlCommentFile)> assemblies)
         {
-            Assemblies = assemblies;
+            Assemblies = assemblies.Select(t => t.Assembly).ToList();
+
+            AssemblyComments = new Dictionary<Assembly, AssemblyXmlComments>();
+            foreach (var (assembly, xmlCommentFile) in assemblies)
+            {
+                if (xmlCommentFile != null)
+                {
+                    AssemblyComments.Add(assembly, new AssemblyXmlComments(xmlCommentFile));
+                }
+            }
+        }
+
+        public List<string> GetTypeScriptComment(Type type)
+        {
+            if (!AssemblyComments.ContainsKey(type.Assembly))
+                return null;
+
+            return AssemblyComments[type.Assembly].GetTypeScriptComment(type);
+        }
+
+        public List<string> GetTypeScriptComment(MemberInfo memberInfo)
+        {
+            if (!AssemblyComments.ContainsKey(memberInfo.DeclaringType.Assembly))
+                return null;
+
+            return AssemblyComments[memberInfo.DeclaringType.Assembly].GetTypeScriptComment(memberInfo);
         }
 
         public IReadOnlyList<Type> FindDerivedTypes(Type type)

--- a/src/TSTypeGen/Processor.cs
+++ b/src/TSTypeGen/Processor.cs
@@ -57,7 +57,7 @@ namespace TSTypeGen
                 }
 
                 var loadedPaths = new List<string>();
-                var assemblies = new List<Assembly>();
+                var assemblies = new List<(Assembly Assembly, string XmlCommentsFile)>();
                 var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(_config.BasePath)));
 
                 var addedDlls = new List<string>();
@@ -95,8 +95,14 @@ namespace TSTypeGen
                         {
                             var assembly = mlc.LoadFromAssemblyPath(fullPath);
 
-                            if (!assemblies.Contains(assembly))
-                                assemblies.Add(assembly);
+                            var xmlCommentsFilePath = Path.ChangeExtension(fullPath, ".xml");
+                            if (!File.Exists(xmlCommentsFilePath))
+                            {
+                                xmlCommentsFilePath = null;
+                            }
+
+                            if (!assemblies.Contains((assembly, xmlCommentsFilePath)))
+                                assemblies.Add((assembly, xmlCommentsFilePath));
                         }
                         catch (Exception)
                         {

--- a/src/TSTypeGen/TsInterfaceMember.cs
+++ b/src/TSTypeGen/TsInterfaceMember.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace TSTypeGen
 {
     public class TsInterfaceMember
@@ -5,11 +7,13 @@ namespace TSTypeGen
         public bool IsOptional { get; set; }
         public string Name { get; }
         public TsTypeReference Type { get; }
+        public MemberInfo MemberInfo { get; }
 
-        public TsInterfaceMember(string name, TsTypeReference type, bool isOptional)
+        public TsInterfaceMember(string name, TsTypeReference type, MemberInfo memberInfo, bool isOptional)
         {
             Name = name;
             Type = type;
+            MemberInfo = memberInfo;
             IsOptional = isOptional;
         }
     }

--- a/src/TSTypeGen/TypeBuilder.cs
+++ b/src/TSTypeGen/TypeBuilder.cs
@@ -101,7 +101,7 @@ namespace TSTypeGen
 
             var isOptional = TypeUtils.GetCustomAttributesData(member).FirstOrDefault(a => a.AttributeType.Name == Constants.TypeScriptOptionalAttributeName) != null;
 
-            return new TsInterfaceMember(name, BuildTsTypeReferenceToPropertyType(member, config, currentTsNamespace, isOptional), isOptional);
+            return new TsInterfaceMember(name, BuildTsTypeReferenceToPropertyType(member, config, currentTsNamespace, isOptional), member, isOptional);
         }
 
         private static TsTypeReference BuildTsTypeReferenceToPropertyType(MemberInfo member, TypeBuilderConfig config, string currentTsNamespace, bool isOptional)


### PR DESCRIPTION
This PR makes it possible to add XML comments on a C# class or property and have them included in the TypeScript definition. Example:

```cs
/// <typeScriptComment>
/// This type is awesome!
/// </typeScriptComment>
[GenerateTypeScriptDefinition]
public abstract class TestClassWithComments
{
    /// <typeScriptComment>
    /// This is the best property you've ever seen!
    /// This is a comment on a new line.
    ///
    /// Wow, this is a comment with an empty line above it!
    /// </typeScriptComment>
    public int Prop1 { get; set; }
    /// <typeScriptComment>
    ///
    /// This comment
    ///   has a bit
    ///  odd whitespace
    ///
    /// formatting. With whitespace at the end.
    ///
    ///
    /// </typeScriptComment>
    public int Prop2 { get; set; }
    /// <summary>
    /// This is a regular summary comment
    /// </summary>
    public int Prop3 { get; set; }
    /// <summary>
    /// This is a regular summary comment
    /// </summary>
    /// <typeScriptComment>
    /// This is a typeScriptComment for a property that also has a summary comment
    /// </typeScriptComment>
    public int Prop4 { get; set; }
    /// <summary>
    /// An empty typeScriptComment prevents this summary from showing up
    /// </summary>
    /// <typeScriptComment>
    /// </typeScriptComment>
    public int Prop5 { get; set; }
    public int Prop6 { get; set; }
}
```

Produces:
```ts
/**
 * This type is awesome!
 */
interface TestClassWithComments {
  /**
   * This is the best property you've ever seen!
   * This is a comment on a new line.
   * 
   * Wow, this is a comment with an empty line above it!
   */
  prop1: number;
  /**
   * 
   * This comment
   *   has a bit
   *  odd whitespace
   * 
   * formatting. With whitespace at the end.
   * 
   * 
   */
  prop2: number;
  /**
   * This is a regular summary comment
   */
  prop3: number;
  /**
   * This is a typeScriptComment for a property that also has a summary comment
   */
  prop4: number;
  prop5: number;
  prop6: number;
}
```

We first look for a `<typeScriptComment>` XML node, and if we can't find one we look for a `<summary>` node. If you want a `<summary>` comment that shouldn't show up in the TS definition you can include a separate `<typeScriptComment>` with either a TS specific comment or an empty `<typeScriptComment>` element which means TSTypeGen won't generate a comment at all.

Note that you need to enable generating an XML comment file for the project in order for TSTypeGen to be able to see the comments.