### PR TITLE
Add linebreak between types for derived type unions

### DIFF
--- a/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
+++ b/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
@@ -130,7 +130,9 @@ declare namespace Test {
     prop1: number;
   }
 
-  type TestDerivedTypesUnionBaseTypes = TestDerivedTypesUnionClass1 | TestDerivedTypesUnionClass3;
+  type TestDerivedTypesUnionBaseTypes =
+    | TestDerivedTypesUnionClass1
+    | TestDerivedTypesUnionClass3;
 
   interface TestDerivedTypesUnionClass1 extends TestDerivedTypesUnionBase {
     prop2: number;
@@ -140,7 +142,8 @@ declare namespace Test {
     prop2: number;
   }
 
-  type MyUnion = TestDerivedTypesUnionClass3;
+  type MyUnion =
+    | TestDerivedTypesUnionClass3;
 
   interface TestDerivedTypesUnionClass3 extends TestDerivedTypesUnionClass2 {
     prop3: number;
@@ -351,7 +354,9 @@ declare namespace Test {
     prop1: number;
   }
 
-  type TestUnionFieldsBaseTypes = TestUnionFieldsClass1 | TestUnionFieldsClass2;
+  type TestUnionFieldsBaseTypes =
+    | TestUnionFieldsClass1
+    | TestUnionFieldsClass2;
 
   interface TestUnionFieldsClass1 extends TestUnionFieldsBase {
     prop2: number;

--- a/src/TSTypeGen/TsTypeDefinition.cs
+++ b/src/TSTypeGen/TsTypeDefinition.cs
@@ -161,7 +161,7 @@ namespace TSTypeGen
                 if (_derivedTypesUnionGeneration?.DerivedTypeReferences.Length > 0)
                 {
                     result.Append(config.NewLine);
-                    result.Append($"{indent}type {_derivedTypesUnionGeneration.DerivedTypesUnionName} = {string.Join(" | ", _derivedTypesUnionGeneration.DerivedTypeReferences.Select(t => t.GetSource()))};");
+                    result.Append($"{indent}type {_derivedTypesUnionGeneration.DerivedTypesUnionName} ={config.NewLine}{indent}  | {string.Join($"{config.NewLine}{indent}  | ", _derivedTypesUnionGeneration.DerivedTypeReferences.Select(t => t.GetSource()))};");
                     result.Append(config.NewLine);
                 }
 


### PR DESCRIPTION
This changes how derived types are formatted to split them up with linebreaks instead of having a single long line for all types. This is also how prettier formats such type unions.

Instead of this:
```ts
type TestDerivedTypesUnionBaseTypes = TestDerivedTypesUnionClass1 | TestDerivedTypesUnionClass3;
```
It now becomes this:
```ts
type TestDerivedTypesUnionBaseTypes =
  | TestDerivedTypesUnionClass1
  | TestDerivedTypesUnionClass3;
```