### PR TITLE
Generate literal types for fields with values known at compile time

### DIFF
--- a/src/TSTypeGen.Tests.Main/can generate readonly fields.cs
+++ b/src/TSTypeGen.Tests.Main/can generate readonly fields.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TSTypeGen.Tests.Shared;
+
+namespace TSTypeGen.Tests.Main
+{
+    [GenerateTypeScriptDefinition]
+    public class TestGenerateFieldsClass1
+    {
+        public int NotAConstant1 = 1;
+        public string NotAConstant2 = "string";
+
+        public const int Prop1 = 1;
+        public const long Prop2 = 2;
+        public const double Prop3 = 3.3;
+        public const string Prop4 = "prop4";
+    }
+}

--- a/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
+++ b/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
@@ -185,6 +185,13 @@ declare namespace Test {
     prop5: string[];
   }
 
+  interface TestGenerateFieldsClass1 {
+    prop1: 1;
+    prop2: 2;
+    prop3: 3.3;
+    prop4: 'prop4';
+  }
+
   interface TestGenerateTypeMemberBase {
     prop1: number;
   }

--- a/src/TSTypeGen/TypeUtils.cs
+++ b/src/TSTypeGen/TypeUtils.cs
@@ -68,6 +68,14 @@ namespace TSTypeGen
                 .ToList();
         }
 
+        public static List<FieldInfo> GetRelevantFields(Type type)
+        {
+            return type
+                .GetFields(BindingFlags.Static | BindingFlags.GetField | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .Where(f => f.IsLiteral)
+                .ToList();
+        }
+
         public static List<PropertyInfo> GetRelevantAndBaseProperties(Type type)
         {
             return type
@@ -99,11 +107,11 @@ namespace TSTypeGen
             }
         }
 
-        public static List<CustomAttributeData> GetCustomAttributesData(PropertyInfo propertyInfo)
+        public static List<CustomAttributeData> GetCustomAttributesData(MemberInfo memberInfo)
         {
             try
             {
-                return propertyInfo.GetCustomAttributesData().Select(a =>
+                return memberInfo.GetCustomAttributesData().Select(a =>
                 {
                     try
                     {


### PR DESCRIPTION
This adds support for including literal types for C# fields with values known at compile time. This is useful for when you serialize multiple models and use a compile time field as the type marker.

This PR changes so that this class:
```cs
public class MyClass
{
    public const string Type = "MyClass";
}
```
is generated as:
```ts
interface MyClass {
  type: 'MyClass';
}
```