### PR TITLE
Fix edge cases around nullable types not being generated as optionals

### DIFF
--- a/src/TSTypeGen.Tests.Main/nullable properties are treated as their underlying type.cs
+++ b/src/TSTypeGen.Tests.Main/nullable properties are treated as their underlying type.cs
@@ -26,8 +26,8 @@ namespace TSTypeGen.Tests.Main
         public decimal? Prop11 { get; set; }
         public bool? Prop12 { get; set; }
         public TestOptionalsStruct? Prop13 { get; set; }
-
         public IEnumerable<TestOptionalsStruct?> Prop14 { get; set; }
         public Dictionary<int, TestOptionalsStruct?> Prop15 { get; set; }
+        public DateTime? Prop16 { get; set; }
     }
 }

--- a/src/TSTypeGen.Tests/.gitattributes
+++ b/src/TSTypeGen.Tests/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
+++ b/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
@@ -341,9 +341,10 @@ declare namespace Test {
     prop10?: number;
     prop11?: number;
     prop12?: boolean;
-    prop13: TestOptionalsStruct;
-    prop14: TestOptionalsStruct[];
-    prop15: {[item: number]: TestOptionalsStruct};
+    prop13?: TestOptionalsStruct;
+    prop14: (TestOptionalsStruct | undefined)[];
+    prop15: {[item: number]: TestOptionalsStruct | undefined};
+    prop16?: external.CustomDateTime;
   }
 
   interface TestOptionalsStruct {

--- a/src/TSTypeGen.Tests/TestGenerate.cs
+++ b/src/TSTypeGen.Tests/TestGenerate.cs
@@ -20,10 +20,10 @@ namespace TSTypeGen.Tests
             {
                 BasePath = assemblyLocation,
                 OutputPath = assemblyLocation,
-                DllPatterns = new List<string> {"TSTypeGen.Tests.Main.dll", "TSTypeGen.Tests.Shared.dll"},
+                DllPatterns = new List<string> { "TSTypeGen.Tests.Main.dll", "TSTypeGen.Tests.Shared.dll" },
                 CustomTypeScriptIgnoreAttributeFullName = "TSTypeGen.Tests.Shared.CustomTypeScriptIgnoreAttribute",
-                NewLine = Environment.NewLine,
-                PropertyWrappers = new Dictionary<string, string>(){ { "TSTypeGen.Tests.Main.WrapMe", "Wrapper"} }
+                NewLine = "\n",
+                PropertyWrappers = new Dictionary<string, string>() { { "TSTypeGen.Tests.Main.WrapMe", "Wrapper" } }
             };
 
             var processor = new Processor(config);

--- a/src/TSTypeGen/TsTypeReference.cs
+++ b/src/TSTypeGen/TsTypeReference.cs
@@ -31,7 +31,33 @@ namespace TSTypeGen
             return new GenericTsTypeReference(genericType, arguments);
         }
 
+        public static TsTypeReference Wrap(TsTypeReference inner, bool isOptional)
+        {
+            return new WrappedTsTypeReference(inner, isOptional);
+        }
+
         public abstract bool Equals(TsTypeDefinition tsTypeDefinition);
+
+        private class WrappedTsTypeReference : TsTypeReference
+        {
+            private readonly TsTypeReference _inner;
+
+            public WrappedTsTypeReference(TsTypeReference inner, bool isOptional)
+            {
+                _inner = inner;
+                IsOptional = isOptional;
+            }
+
+            public override bool Equals(TsTypeDefinition tsTypeDefinition)
+            {
+                return _inner.Equals(tsTypeDefinition);
+            }
+
+            public override string GetSource()
+            {
+                return _inner.GetSource();
+            }
+        }
 
         private class SimpleTsTypeReference : TsTypeReference
         {

--- a/src/TSTypeGen/TypeBuilder.cs
+++ b/src/TSTypeGen/TypeBuilder.cs
@@ -200,7 +200,7 @@ namespace TSTypeGen
 
             if (typeFullName != null && config.TypeMappings.TryGetValue(typeFullName, out var mappedType))
             {
-                return mappedType;
+                return TsTypeReference.Wrap(mappedType, isOptional);
             }
 
             var typeScriptTypeAttribute = GetTypeScriptTypeAttribute(type);
@@ -267,11 +267,11 @@ namespace TSTypeGen
                     var result = default(TsTypeReference);
                     if (namespaceName == currentTsNamespace)
                     {
-                        result = TsTypeReference.Simple(derivedTypesUnionName ?? typeName);
+                        result = TsTypeReference.Simple(derivedTypesUnionName ?? typeName, isOptional);
                     }
                     else
                     {
-                        result = TsTypeReference.Simple(namespaceName + "." + (derivedTypesUnionName ?? typeName));
+                        result = TsTypeReference.Simple(namespaceName + "." + (derivedTypesUnionName ?? typeName), isOptional);
                     }
 
                     if (result != null)
@@ -287,7 +287,7 @@ namespace TSTypeGen
                 }
             }
 
-            return TsTypeReference.Simple("unknown");
+            return TsTypeReference.Simple("unknown", isOptional);
         }
 
         private static Type GetUnderlyingNullableType(Type type)


### PR DESCRIPTION
This PR fixes a couple of bugs around generating nullables in C# correctly:

1. Mapped types was not handled correctly when they're nullable. Such as `DateTime` which is always a type mapped in config. `DateTime?` always got the mapped type rather than the mapped type as optional.
2. `isOptional` was not passed on for all property types, which led to structs not becoming optional at all.

All tests fail for me because of this commit:
https://github.com/avensia-oss/tstypegen/commit/c734a4478c6f8b65d1cd4720ddcfb6b959491e36

Not sure if it's just for me, but I had to temporarily revert it in order to run the tests.