### PR TITLE
Add option to wrap const enum references in template strings

### DIFF
--- a/src/TSTypeGen/Config.cs
+++ b/src/TSTypeGen/Config.cs
@@ -15,6 +15,13 @@ namespace TSTypeGen
         public Dictionary<string, string> TypeMappings { get; } = new Dictionary<string, string>();
         public Dictionary<string, string> PropertyWrappers { get; set;  } = new Dictionary<string, string>();
         public string CustomTypeScriptIgnoreAttributeFullName { get; set; }
+        // Babel doesn't support const enums but there's one wierd trick where if you wrap the const enum in a template
+        // string then Babel stops complaining. So if you do:
+        // const x: TheEnum;
+        // Babel won't be happy. But if you do:
+        // const x: `${TheEnum}`;
+        // Babel won't complain because it doesn't understand the type.
+        public bool WrapConstEnumsInTemplateStrings { get; set; }
 
         public static Config ReadFromFile(string path)
         {

--- a/src/TSTypeGen/Processor.cs
+++ b/src/TSTypeGen/Processor.cs
@@ -230,7 +230,7 @@ namespace TSTypeGen
             }
 
             var mappings = ImmutableDictionary.CreateRange(typeMappings);
-            _typeBuilderConfig = new TypeBuilderConfig(mappings, _config.CustomTypeScriptIgnoreAttributeFullName);
+            _typeBuilderConfig = new TypeBuilderConfig(mappings, _config.CustomTypeScriptIgnoreAttributeFullName, _config.WrapConstEnumsInTemplateStrings);
         }
 
         private async Task<bool> LoadAllDllsAndUpdateOrVerifyAllTypes(bool verify)

--- a/src/TSTypeGen/TypeBuilder.cs
+++ b/src/TSTypeGen/TypeBuilder.cs
@@ -264,14 +264,22 @@ namespace TSTypeGen
 
                     var typeName = TypeUtils.GetNameWithoutGenericArity(type);
 
+                    var prefix = "";
+                    var suffix = "";
+                    if (type.IsEnum && config.WrapConstEnumsInTemplateStrings)
+                    {
+                        prefix = "`${";
+                        suffix = "}`";
+                    }
+
                     var result = default(TsTypeReference);
                     if (namespaceName == currentTsNamespace)
                     {
-                        result = TsTypeReference.Simple(derivedTypesUnionName ?? typeName, isOptional);
+                        result = TsTypeReference.Simple(prefix + (derivedTypesUnionName ?? typeName) + suffix, isOptional);
                     }
                     else
                     {
-                        result = TsTypeReference.Simple(namespaceName + "." + (derivedTypesUnionName ?? typeName), isOptional);
+                        result = TsTypeReference.Simple(prefix + namespaceName + "." + (derivedTypesUnionName ?? typeName) + suffix, isOptional);
                     }
 
                     if (result != null)

--- a/src/TSTypeGen/TypeBuilderConfig.cs
+++ b/src/TSTypeGen/TypeBuilderConfig.cs
@@ -7,11 +7,13 @@ namespace TSTypeGen
     {
         public ImmutableDictionary<string, TsTypeReference> TypeMappings { get; }
         public string CustomTypeScriptIgnoreAttributeFullName { get; set; }
+        public bool WrapConstEnumsInTemplateStrings { get; set; }
 
-        public TypeBuilderConfig(ImmutableDictionary<string, TsTypeReference> typeMappings, string customTypeScriptIgnoreAttributeFullName)
+        public TypeBuilderConfig(ImmutableDictionary<string, TsTypeReference> typeMappings, string customTypeScriptIgnoreAttributeFullName, bool wrapConstEnumsInTemplateStrings)
         {
             TypeMappings = typeMappings;
             CustomTypeScriptIgnoreAttributeFullName = customTypeScriptIgnoreAttributeFullName;
+            WrapConstEnumsInTemplateStrings = wrapConstEnumsInTemplateStrings;
         }
     }
 }


### PR DESCRIPTION
This makes life a bit easier when dealing with Babel which is needed for React Native.

The PR adds a config flag that will change this:
```ts
const enum MyEnum = {
  Xxx = 'xxx',
  Yyy = 'yyy',
}

interface SomeInterface {
  someProp: MyEnum;
}
```

Into this:
```ts
const enum MyEnum = {
  Xxx = 'xxx',
  Yyy = 'yyy',
}

interface SomeInterface {
  someProp: `${MyEnum}`;
}
```

This makes the const enum behave like a string union (eg `'red' | 'blue' | 'green'`) but without having to generate it like string unions.