### PR TITLE
Add cli.js file as bin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@avensia-oss/tstypegen",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@avensia-oss/tstypegen",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "bin": {
-        "tstypegen": "bin/TSTypeGen.exe"
+        "tstypegen": "dist/main.js"
       },
       "devDependencies": {
         "@types/node": "^14.14.25",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A tool to generate TypeScript types from C# types",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
+  "bin": {
+    "tstypegen": "./dist/cli.js"
+  },
   "repository": "https://github.com/avensia-oss/tstypegen",
   "author": "Anders Ekdahl <anders.ekdahl@avensia.com>",
   "license": "MIT",
@@ -20,7 +23,6 @@
     "bin/*.deps.json",
     "dist/"
   ],
-  "bin": "./bin/TSTypeGen.exe",
   "devDependencies": {
     "@types/node": "^14.14.25",
     "typescript": "~3.4.5"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,13 +83,21 @@ async function main() {
 function getVariable(names: string[], expectBool?: false): string | undefined;
 function getVariable(names: string[], expectBool: true): boolean;
 function getVariable(names: string[], expectBool = false) {
-  for (const arg of args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
     for (const name of names) {
-      if (expectBool && arg === name) {
-        return true;
-      }
-      if (!expectBool && arg.startsWith(`${name}=`)) {
-        return arg.slice(name.length + 1);
+      if (expectBool) {
+        if (arg === name) {
+          return true;
+        }
+      } else {
+        if (arg.startsWith(`${name}=`)) {
+          return arg.slice(name.length + 1);
+        }
+        if (arg === name) {
+          return args[++i];
+        }
       }
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,100 @@
+import tsTypeGen from './main';
+
+const args = process.argv.slice(2);
+const HELP_ARG_NAMES = ['--help', '-h'];
+const VERSION_ARG_NAMES = ['--version', '-v'];
+const SOLUTION_ARG_NAMES = ['--solution', '-s'];
+const PROJECT_ARG_NAMES = ['--project', '-p'];
+const CONFIG_ARG_NAMES = ['--config', '-c'];
+const VERIFY_ARG_NAMES = ['--verify', '-t'];
+
+if (getVariable(HELP_ARG_NAMES, true)) {
+  help();
+} else if (getVariable(VERSION_ARG_NAMES, true)) {
+  version();
+} else {
+  main();
+}
+
+function help() {
+  console.info(`Examples:
+tstypegen ${SOLUTION_ARG_NAMES[0]}=path/to/file.sln ${CONFIG_ARG_NAMES[0]}=path/to/config.json
+tstypegen ${PROJECT_ARG_NAMES[0]}=path/to/file.csproj ${CONFIG_ARG_NAMES[0]}=path/to/config.json
+tstypegen ${PROJECT_ARG_NAMES[0]}=path/to/file.csproj ${CONFIG_ARG_NAMES[0]}=path/to/config.json ${VERIFY_ARG_NAMES[0]}
+
+Options:
+${HELP_ARG_NAMES.join(', ').padEnd(32)} Print this message.
+${VERSION_ARG_NAMES.join(', ').padEnd(32)} Print the version.
+${SOLUTION_ARG_NAMES.join(', ').padEnd(32)} Path to solution file.
+${PROJECT_ARG_NAMES.join(', ').padEnd(32)} Path to project file.
+${CONFIG_ARG_NAMES.join(', ').padEnd(32)} Path to config file.
+${VERIFY_ARG_NAMES.join(', ').padEnd(32)} Verify generated types instead of generating them.`);
+}
+
+async function version() {
+  // Trick TS from transpiling package.json
+  const pkg = await import('../package.json' + '');
+  console.info(pkg.version);
+}
+
+async function main() {
+  if (args.length > 0) {
+    const solutionFile = getVariable(SOLUTION_ARG_NAMES);
+    const projectFile = getVariable(PROJECT_ARG_NAMES);
+    const configFile = getVariable(CONFIG_ARG_NAMES);
+    const verify = getVariable(VERIFY_ARG_NAMES, true);
+
+    try {
+      if (typeof solutionFile === typeof projectFile) {
+        throw new Error(
+          'Choose the path to either a project or solution file.'
+        );
+      }
+
+      if (typeof configFile === 'undefined') {
+        throw new Error('Enter a path to the config file.');
+      }
+
+      if (typeof solutionFile === 'string') {
+        await tsTypeGen({
+          solutionFile,
+          configFile,
+          verify,
+        });
+      } else if (typeof projectFile === 'string') {
+        await tsTypeGen({
+          projectFile,
+          configFile,
+          verify,
+        });
+      }
+    } catch (e) {
+      if (e instanceof Error) {
+        console.error(e.message);
+      } else {
+        throw e;
+      }
+    }
+  } else {
+    help();
+  }
+}
+
+function getVariable(names: string[], expectBool?: false): string | undefined;
+function getVariable(names: string[], expectBool: true): boolean;
+function getVariable(names: string[], expectBool = false) {
+  for (const arg of args) {
+    for (const name of names) {
+      if (expectBool && arg === name) {
+        return true;
+      }
+      if (!expectBool && arg.startsWith(`${name}=`)) {
+        return arg.slice(name.length + 1);
+      }
+    }
+  }
+
+  if (expectBool) {
+    return false;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ function tsTypeGen(options: (Solution | Project) & Options) {
   if ('configFile' in options) {
     args.push(`--cfg=${JSON.stringify(options.configFile)}`);
   } else {
-    throw new Error('You must specify a TSTypeGen config file');
+    throw new Error('You must specify a TSTypeGen config file.');
   }
 
   if (options.verify) {
@@ -36,7 +36,7 @@ function tsTypeGen(options: (Solution | Project) & Options) {
       if (error) {
         if (stderr) {
           process.stdout.write(stderr);
-          reject(new Error());
+          reject();
         } else {
           reject(error);
         }
@@ -44,10 +44,10 @@ function tsTypeGen(options: (Solution | Project) & Options) {
         if (stdout) {
           process.stdout.write(stdout);
         } else {
-          console.log(
+          console.info(
             options.verify
-              ? 'All type definitions verified'
-              : 'No type definitions changed'
+              ? 'All type definitions verified.'
+              : 'No type definitions changed.'
           );
         }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,5 +66,6 @@
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     // "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
We got this error on CI that we assume is because `bin/TSTypeGen.exe` doesn't exists. So I added a small cli.js file and reference to that file as `bin` instead.

```bash
npm ERR! code ENOENT
npm ERR! syscall chmod
npm ERR! path D:\a\1\s\node_modules\@avensia-oss\tstypegen\bin\TSTypeGen.exe
npm ERR! errno -4058
npm ERR! enoent ENOENT: no such file or directory, chmod 'D:\a\1\s\node_modules\@avensia-oss\tstypegen\bin\TSTypeGen.exe'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 