### PR TITLE
fix(comments xml): check only the canonical for null to avoid null ref exception

### DIFF
--- a/src/TSTypeGen/TsTypeDefinition.cs
+++ b/src/TSTypeGen/TsTypeDefinition.cs
@@ -104,7 +104,7 @@ namespace TSTypeGen
                         result.Append(config.NewLine);
                     }
 
-                    if (canonicalType != null || typeScriptClassComment != null)
+                    if (canonicalType != null)
                     {
                         result.Append(config.NewLine);
                         result.Append($"{indent} * {dotNetTypeComment}");


### PR DESCRIPTION
When processing xml documentation for a dll this checks for either a typeScriptClassComment or canonical is present.
It seems the typeScriptClassComment is often populated but the 
canonicalType is/can be null, despite that being the only param used inside the if.

```
if (canonicalType != null || typeScriptClassComment != null)
{
}
```