### PR TITLE
Look for .NET comments on interfaces

### DIFF
--- a/src/TSTypeGen.Tests.Main/can generate comments.cs
+++ b/src/TSTypeGen.Tests.Main/can generate comments.cs
@@ -48,4 +48,21 @@ namespace TSTypeGen.Tests.Main
         public int Prop5 { get; set; }
         public int Prop6 { get; set; }
     }
+
+    /// <summary>
+    /// This is a comment on the interface
+    /// </summary>
+    public interface IInterfaceWithComments
+    {
+        /// <summary>
+        /// This is an interface comment
+        /// </summary>
+        public int Prop1 { get; set; }
+    }
+
+    [GenerateTypeScriptDefinition]
+    public class TestClassWithInterface : IInterfaceWithComments
+    {
+        public int Prop1 { get; set; }
+    }
 }

--- a/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
+++ b/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
@@ -145,6 +145,16 @@ declare namespace Test {
     prop6: number;
   }
 
+  /**
+   * This is a comment on the interface
+   */
+  interface TestClassWithInterface {
+    /**
+     * This is an interface comment
+     */
+    prop1: number;
+  }
+
   const enum TestConstEnum {
     FirstValue = 'firstValue',
     SecondValue = 'secondValue',

--- a/src/TSTypeGen/TsTypeDefinition.cs
+++ b/src/TSTypeGen/TsTypeDefinition.cs
@@ -78,6 +78,16 @@ namespace TSTypeGen
                     name = _parentToAugument.Name;
 
                 var typeScriptClassComment = generatorContext.GetTypeScriptComment(_type);
+                if (typeScriptClassComment == null)
+                {
+                    var interfaces = _type.GetInterfaces();
+                    foreach (var iface in interfaces)
+                    {
+                        typeScriptClassComment = generatorContext.GetTypeScriptComment(iface);
+                        if (typeScriptClassComment != null)
+                            break;
+                    }
+                }
 
                 if (TypeBuilder.ShouldGenerateDotNetTypeNamesAsJsDocComment(_type))
                 {
@@ -174,7 +184,19 @@ namespace TSTypeGen
                         if (m.IsOptional || m.Type.IsOptional)
                             optional = "?";
                     }
+
                     var typeScriptMemberComment = generatorContext.GetTypeScriptComment(m.MemberInfo);
+                    if (typeScriptMemberComment == null)
+                    {
+                        var interfaceMembers = m.MemberInfo.DeclaringType.GetInterfaces().SelectMany(i => i.GetMember(m.MemberInfo.Name)).Where(m => m != null).ToList();
+                        foreach (var interfaceMember in interfaceMembers)
+                        {
+                            typeScriptMemberComment = generatorContext.GetTypeScriptComment(interfaceMember);
+                            if (typeScriptMemberComment != null)
+                                break;
+                        }
+                    }
+
                     if (typeScriptMemberComment != null)
                     {
                         result.Append($"{indent}  /**");


### PR DESCRIPTION
This adds .NET comments from interfaces to the class properties so you don't have to repeat the comments in .NET on every implementation class of the interface since the TS output doesn't use `extends` for .NET interfaces and just for base classes.

Reading the changed test in the PR should explain what's happening.