### PR TITLE
Look at interfaces when determining if a property is optional

### DIFF
--- a/src/TSTypeGen.Tests.Main/optional properties works.cs
+++ b/src/TSTypeGen.Tests.Main/optional properties works.cs
@@ -34,4 +34,16 @@ namespace TSTypeGen.Tests.Main
         [TypeScriptOptional]
         public TestOptionalPropertiesNestedClass Prop6 { get; set; }
     }
+
+    public interface InterfaceWithOptional
+    {
+        [TypeScriptOptional]
+        public int Prop1 { get; set; }
+    }
+
+    [GenerateTypeScriptDefinition]
+    public class TestOptionalPropertiesFromInterfaceClass : InterfaceWithOptional
+    {
+        public int Prop1 { get; set; }
+    }
 }

--- a/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
+++ b/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
@@ -324,6 +324,10 @@ declare namespace Test {
     Value2 = 'value2',
   }
 
+  interface TestOptionalPropertiesFromInterfaceClass {
+    prop1?: number;
+  }
+
   interface TestOptionalPropertiesNestedClass {
     nestedProp1: number;
   }

--- a/src/TSTypeGen/TypeBuilder.cs
+++ b/src/TSTypeGen/TypeBuilder.cs
@@ -99,7 +99,10 @@ namespace TSTypeGen
                 name = StringUtils.ToCamelCase(member.Name);
             }
 
-            var isOptional = TypeUtils.GetCustomAttributesData(member).FirstOrDefault(a => a.AttributeType.Name == Constants.TypeScriptOptionalAttributeName) != null;
+            var membersToCheckForOptional = new List<MemberInfo> { member };
+            membersToCheckForOptional.AddRange(member.DeclaringType.GetInterfaces().SelectMany(i => i.GetMember(member.Name)).Where(m => m != null));
+
+            var isOptional = membersToCheckForOptional.SelectMany(m => TypeUtils.GetCustomAttributesData(m)).FirstOrDefault(a => a.AttributeType.Name == Constants.TypeScriptOptionalAttributeName) != null;
 
             return new TsInterfaceMember(name, BuildTsTypeReferenceToPropertyType(member, config, currentTsNamespace, isOptional), member, isOptional);
         }


### PR DESCRIPTION
In similar fashion as #12 this fixes so that optional members are determined not only by having `[TypeScriptOptional]` on the class itself but also by looking at the interfaces the class implements to see if the property has `[TypeScriptOptional]`. The updated test should tell you more.