### PR TITLE
Add @deprecated to [Obsolete] classes and members

### DIFF
--- a/src/TSTypeGen.Tests.Main/obsolete is generated as deprecated.cs
+++ b/src/TSTypeGen.Tests.Main/obsolete is generated as deprecated.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TSTypeGen.Tests.Shared;
+
+namespace TSTypeGen.Tests.Main
+{
+    [Obsolete]
+    [GenerateTypeScriptDefinition]
+    public class TestGenerateObsoleteClass
+    {
+        [Obsolete]
+        public int Prop1 { get; set; }
+    }
+
+    [Obsolete("Don't use this ok?")]
+    [GenerateTypeScriptDefinition]
+    public class TestGenerateObsoleteClassWithComment
+    {
+        [Obsolete("If you use this you'll be fired")]
+        public int Prop1 { get; set; }
+    }
+
+    /// <summary>
+    /// This should not be used
+    /// </summary>
+    [Obsolete("Don't use this ok?")]
+    [GenerateTypeScriptDefinition]
+    public class TestGenerateObsoleteClassWithCommentAndSummary
+    {
+        /// <summary>
+        /// Don't use this ok?
+        /// </summary>
+        [Obsolete("If you use this you'll be fired")]
+        public int Prop1 { get; set; }
+    }
+
+    /// <summary>
+    /// This should not be used at all
+    /// </summary>
+    [Obsolete("Please don't use this ok?")]
+    [GenerateTypeScriptDefinition]
+    [GenerateDotNetTypeNamesAsJsDocComment]
+    public class TestGenerateObsoleteClassWithCommentAndSummaryAndDotNetType
+    {
+        /// <summary>
+        /// Don't use this ok?
+        /// </summary>
+        [Obsolete("If you use this you'll be fired!")]
+        public int Prop1 { get; set; }
+    }
+}

--- a/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
+++ b/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
@@ -236,6 +236,47 @@ declare namespace Test {
     prop4: 'prop4';
   }
 
+  /** @deprecated */
+  interface TestGenerateObsoleteClass {
+    /** @deprecated */
+    prop1: number;
+  }
+
+  /** @deprecated Don't use this ok? */
+  interface TestGenerateObsoleteClassWithComment {
+    /** @deprecated If you use this you'll be fired */
+    prop1: number;
+  }
+
+  /**
+   * This should not be used
+   *
+   * @deprecated Don't use this ok?
+   */
+  interface TestGenerateObsoleteClassWithCommentAndSummary {
+    /**
+     * Don't use this ok?
+     *
+     * @deprecated If you use this you'll be fired
+     */
+    prop1: number;
+  }
+
+  /**
+   * This should not be used at all
+   *
+   * @DotNetTypeName TSTypeGen.Tests.Main.TestGenerateObsoleteClassWithCommentAndSummaryAndDotNetType,TSTypeGen.Tests.Main
+   * @deprecated Please don't use this ok?
+   */
+  interface TestGenerateObsoleteClassWithCommentAndSummaryAndDotNetType {
+    /**
+     * Don't use this ok?
+     *
+     * @deprecated If you use this you'll be fired!
+     */
+    prop1: number;
+  }
+
   interface TestGenerateTypeMemberBase {
     prop1: number;
   }

--- a/src/TSTypeGen/Constants.cs
+++ b/src/TSTypeGen/Constants.cs
@@ -18,6 +18,7 @@ namespace TSTypeGen
         public const string GenerateTypeScriptDerivedTypesUnionAttributeName = "GenerateTypeScriptDerivedTypesUnionAttribute";
         public const string GenerateTypeScriptTypeMemberAttributeName = "GenerateTypeScriptTypeMemberAttribute";
         public const string GenerateTypeScriptDotNetNameAttributeName = "GenerateTypeScriptDotNetNameAttribute";
+        public const string ObsoleteAttributeName = "ObsoleteAttribute";
         public const string DefaultTypeMemberName = "$type";
     }
 }


### PR DESCRIPTION
This adds support for adding `@deprecated` JSDoc comments to interfaces and members which has `[Obsolete]` attributes. It also cleans up how we add JSDoc comments for interfaces and members which was kinda buggy and had some duplicated code.

See tests for example.