### PR TITLE
Generate const booleans as constants

### DIFF
--- a/src/TSTypeGen.Tests.Main/can generate readonly fields.cs
+++ b/src/TSTypeGen.Tests.Main/can generate readonly fields.cs
@@ -15,5 +15,6 @@ namespace TSTypeGen.Tests.Main
         public const long Prop2 = 2;
         public const double Prop3 = 3.3;
         public const string Prop4 = "prop4";
+        public const bool Prop5 = true;
     }
 }

--- a/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
+++ b/src/TSTypeGen.Tests/TestFixtures/Test.d.ts
@@ -234,6 +234,7 @@ declare namespace Test {
     prop2: 2;
     prop3: 3.3;
     prop4: 'prop4';
+    prop5: true;
   }
 
   interface TestGenerateTypeMemberBase {

--- a/src/TSTypeGen/TypeBuilder.cs
+++ b/src/TSTypeGen/TypeBuilder.cs
@@ -133,6 +133,10 @@ namespace TSTypeGen
                 {
                     typeValue = l.ToString(CultureInfo.InvariantCulture);
                 }
+                else if (constantValue is bool b)
+                {
+                    typeValue = b ? "true" : "false";
+                }
 
                 if (typeValue != default)
                     return TsTypeReference.Simple(typeValue, isOptional);


### PR DESCRIPTION
This already worked for all other types of constants, but not for booleans