### PR TITLE
Fix line ending issue in tests

### DIFF
--- a/src/TSTypeGen.Tests/TestGenerate.cs
+++ b/src/TSTypeGen.Tests/TestGenerate.cs
@@ -64,7 +64,7 @@ namespace TSTypeGen.Tests
                 var testFixtureSource = await File.ReadAllTextAsync(testFixture);
                 var generatedTestFixtureSource = await File.ReadAllTextAsync(generatedTestFixture);
 
-                Assert.AreEqual(testFixtureSource, generatedTestFixtureSource);
+                Assert.AreEqual(testFixtureSource.Replace("\r\n", "\n"), generatedTestFixtureSource.Replace("\r\n", "\n"));
             }
         }
 


### PR DESCRIPTION
Build should no longer fail due to CR/LF differences