### PR TITLE
Add support for embedded declarations

### DIFF
--- a/src/TSTypeGen/Config.cs
+++ b/src/TSTypeGen/Config.cs
@@ -24,6 +24,7 @@ namespace TSTypeGen
         // const x: `${TheEnum}` = 'value';
         // Then both Babel and Typscript will be satisfied
         public bool WrapConstEnumsInTemplateStrings { get; set; }
+        public bool UseEmbeddedDeclarations { get; set; }
 
         public static Config ReadFromFile(string path)
         {


### PR DESCRIPTION
This PR adds an opt-in feature to embed manually handled declarations.

**Background**
There are situations where you want to manually handle TS declarations, for instance when you are creating proxy types for third party libraries. In this scenario, we want to output the manually handled declarations in the same process as the "by-reflection generated" ones.

By setting `useEmbeddedDeclarations` to `true` in the configuration, tstypegen will scan the assembly for any embedded resources [matching `*.d.ts`] and output them along with the dynamically generated declarations.

To embed a manually handled declaration, add the following to the csproj:

```
<ItemGroup>
  <None Remove="Manual.d.ts" />
</ItemGroup>
<ItemGroup>
  <EmbeddedResource Include="Manual.d.ts">
    <LogicalName>Manual.d.ts</LogicalName>
  </EmbeddedResource>
</ItemGroup>
```

Note: If you don't set the `<LogicalName>` for the resource, it will be prepended with the default namespace in the assembly, which may or may not be desired.