### PR TITLE
Fix loading assemblies that use other .net versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -521,3 +521,4 @@ MigrationBackup/
 # End of https://www.gitignore.io/api/csharp,dotnetcore,visualstudio
 
 dist/
+.idea/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Options:
 
 - `-c`: Specify the configuration file (see below for format)
 - `-verify`: Do not update any definitions but instead return an error if any files need updates. This can be used on a CI server to detect if all types have been built and checked in.
+- `p`: Specify directories containing NuGet caches. If invoking the tool from a .targets file, specify "-p &quot;$(NuGetPackageFolders)\&quot; (Note the final backslash that is required because the MSBuild variable ends with a backslash, and if we don't have 2, the quote will be escaped which is bad)
+- `f`: Specify target framework version. If invoking the tool from a .targets file, specify "-f $(TargetFrameworkVersion)"
 
 In order to generate a file, the minimum you need to do is define a C# attribute called `GenerateTypeScriptDefinitionAttribute`, like this:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Options:
 - `-verify`: Do not update any definitions but instead return an error if any files need updates. This can be used on a CI server to detect if all types have been built and checked in.
 - `p`: Specify directories containing NuGet caches. If invoking the tool from a .targets file, specify "-p &quot;$(NuGetPackageFolders)\&quot; (Note the final backslash that is required because the MSBuild variable ends with a backslash, and if we don't have 2, the quote will be escaped which is bad)
 - `f`: Specify target framework version. If invoking the tool from a .targets file, specify "-f $(TargetFrameworkVersion)"
+- `d`: Specify dllPatterns on the command line instead of in the config. Separate patterns with , or ;
 
 In order to generate a file, the minimum you need to do is define a C# attribute called `GenerateTypeScriptDefinitionAttribute`, like this:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/tstypegen",
-  "version": "3.1.0-rc0002",
+  "version": "3.1.0",
   "description": "A tool to generate TypeScript types from C# types",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/tstypegen",
-  "version": "3.1.0-rc0001",
+  "version": "3.1.0-rc0002",
   "description": "A tool to generate TypeScript types from C# types",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/tstypegen",
-  "version": "3.0.1",
+  "version": "3.1.0-rc0001",
   "description": "A tool to generate TypeScript types from C# types",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/src/TSTypeGen/Config.cs
+++ b/src/TSTypeGen/Config.cs
@@ -28,6 +28,8 @@ namespace TSTypeGen
         public bool UseConstEnums { get; set; } = true;
         public bool GenerateComments { get; set; } = true;
         public bool GenerateInterfaceProperties { get; set; } = true;
+        public List<string> PackagesDirectories { get; set; }
+        public string TargetFrameworkVersion { get; set; }
 
         public static Config ReadFromFile(string path)
         {

--- a/src/TSTypeGen/CustomMetadataAssemblyResolver.cs
+++ b/src/TSTypeGen/CustomMetadataAssemblyResolver.cs
@@ -18,10 +18,10 @@ namespace TSTypeGen
 
         private readonly List<DirectoryInfo> _nugetCaches = null;
 
-        public CustomMetadataAssemblyResolver(PathAssemblyResolver pathAssemblyResolver)
+        public CustomMetadataAssemblyResolver(PathAssemblyResolver pathAssemblyResolver, ICollection<string> packagesDirectories)
         {
             _pathAssemblyResolver = pathAssemblyResolver;
-            _nugetCaches = GetCaches();
+            _nugetCaches = packagesDirectories?.Count > 0 ? packagesDirectories.Select(d => new DirectoryInfo(d)).ToList() : GetCaches();
         }
 
         public override Assembly Resolve(MetadataLoadContext context, AssemblyName assemblyName)

--- a/src/TSTypeGen/Processor.cs
+++ b/src/TSTypeGen/Processor.cs
@@ -54,7 +54,7 @@ namespace TSTypeGen
                 return null;
             }
             // This is fishy, but I can't find another way to locate all required framework assemblies.
-            var dotnetDirectory = Path.GetDirectoryName(RuntimeEnvironment.GetRuntimeDirectory().TrimEnd('\\'));
+            var dotnetDirectory = Path.GetDirectoryName(RuntimeEnvironment.GetRuntimeDirectory().TrimEnd('\\', '/'));
             var aspnetDirectory = Path.Combine(Path.GetDirectoryName(dotnetDirectory), "Microsoft.AspNetCore.App");
             var dotnetVersions = Directory.GetDirectories(dotnetDirectory).Select(Path.GetFileName);
             var aspnetVersions = Directory.GetDirectories(aspnetDirectory).Select(Path.GetFileName);

--- a/src/TSTypeGen/Processor.cs
+++ b/src/TSTypeGen/Processor.cs
@@ -163,6 +163,20 @@ namespace TSTypeGen
                     }
                 }
 
+                // Locate all dlls that exist in a directory in which we have locaed a file to process. This allows generating types for a single file in the output directory
+                foreach (var directory in patternPaths.Select(Path.GetDirectoryName).Distinct())
+                {
+                    foreach (var dll in Directory.GetFiles(directory, "*.dll"))
+                    {
+                        var fileName = Path.GetFileName(dll);
+                        if (!addedDlls.Contains(fileName))
+                        {
+                            dllPaths.Add(dll);
+                            addedDlls.Add(fileName);
+                        }
+                    }
+                }
+
                 var resolver = new CustomMetadataAssemblyResolver(new PathAssemblyResolver(dllPaths), _config.PackagesDirectories);
                 var mlc = new MetadataLoadContext(resolver);
 

--- a/src/TSTypeGen/Program.cs
+++ b/src/TSTypeGen/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Mono.Options;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -38,12 +39,16 @@ namespace TSTypeGen
         static int Main(string[] args)
         {
             string configPath = null;
+            string[] packagesDirectories = null;
+            string frameworkVersion = null;
             bool showHelp = false, verifyOnly = false;
 
             var options = new OptionSet
             {
                 { "v|verify", "Verify that the generated types are as expected, and return a non-zero exit code if they do not match. Nothing will be updated in this mode.", _ => verifyOnly = true },
                 { "c|cfg=", "Specify a file that contains configuration", s => configPath = s },
+                { "p|packages=", "Specify directory where NuGet packages are stored", s => packagesDirectories = s.Split(";") },
+                { "f|framework=", "Specify the framework version (eg. v7.0)", s => frameworkVersion = s },
                 { "h|?|help", "Show this message and exit", _ => showHelp = true },
             };
 
@@ -73,6 +78,23 @@ namespace TSTypeGen
             if (config == null)
             {
                 return 1;
+            }
+
+            if (packagesDirectories != null && packagesDirectories.Length > 0)
+            {
+                config.PackagesDirectories ??= new List<string>();
+                foreach (var d in packagesDirectories)
+                {
+                    if (!config.PackagesDirectories.Contains(d))
+                    {
+                        config.PackagesDirectories.Add(d);
+                    }
+                }
+            }
+
+            if (frameworkVersion != null)
+            {
+                config.TargetFrameworkVersion = frameworkVersion;
             }
 
             var processor = new Processor(config);

--- a/src/TSTypeGen/Program.cs
+++ b/src/TSTypeGen/Program.cs
@@ -40,6 +40,7 @@ namespace TSTypeGen
         {
             string configPath = null;
             string[] packagesDirectories = null;
+            string[] dllPatterns = null;
             string frameworkVersion = null;
             bool showHelp = false, verifyOnly = false;
 
@@ -49,6 +50,7 @@ namespace TSTypeGen
                 { "c|cfg=", "Specify a file that contains configuration", s => configPath = s },
                 { "p|packages=", "Specify directory where NuGet packages are stored", s => packagesDirectories = s.Split(";") },
                 { "f|framework=", "Specify the framework version (eg. v7.0)", s => frameworkVersion = s },
+                { "d|dllpatterns=", "Specify dll patterns on the command line instead of in the config file. Separate patterns with , or ;", s => dllPatterns = s.Split(',', ';') },
                 { "h|?|help", "Show this message and exit", _ => showHelp = true },
             };
 
@@ -90,6 +92,15 @@ namespace TSTypeGen
                         config.PackagesDirectories.Add(d);
                     }
                 }
+            }
+            if (dllPatterns?.Length > 0)
+            {
+                if (config.DllPatterns?.Count > 0)
+                {
+                    Console.Error.WriteLine("Cannot specify dll patterns both in the config file and on the command line");
+                    return 1;
+                }
+                config.DllPatterns = dllPatterns.ToList();
             }
 
             if (frameworkVersion != null)


### PR DESCRIPTION
Make it possible to generate types for assemblies that target a higher dotnet version than this tool is built for.

Also make it possible to define the directory for nuget caches, which is required if the NUGET_PACKAGES environment variable is set, and this variable needs to be set in order for Azure devops caching to work.

And also make it possible to specify dllPatterns on the command line.

After merging this, other projects that use a .targets file probably want to change it to something like this:

```
<Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)tstypegen\TSTypeGen.dll&quot; -c &quot;$(MSBuildThisFileDirectory)TSTypeGen.json&quot; -p &quot;$(NuGetPackageFolders)\&quot; -f &quot;$(TargetFrameworkVersion)&quot;" />
```