### PR TITLE
Bump netversion

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.x.x
+        dotnet-version: 8.x.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avensia-oss/tstypegen",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A tool to generate TypeScript types from C# types",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/src/TSTypeGen.Tests.Main/TSTypeGen.Tests.Main.csproj
+++ b/src/TSTypeGen.Tests.Main/TSTypeGen.Tests.Main.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/TSTypeGen.Tests/TSTypeGen.Tests.csproj
+++ b/src/TSTypeGen.Tests/TSTypeGen.Tests.csproj
@@ -1,20 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>8</LangVersion>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="System.CodeDom" Version="5.0.0" />
+    <PackageReference Include="System.CodeDom" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TSTypeGen/Processor.cs
+++ b/src/TSTypeGen/Processor.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 

--- a/src/TSTypeGen/TSTypeGen.csproj
+++ b/src/TSTypeGen/TSTypeGen.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Nuclear.Assemblies" Version="1.2.0" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="5.0.1" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bump runtime from .NET 6 to .NET 8 - with a rollforward directive to run also on later versions.

Since tstypegen was built with .NET 6, it required consumers to have .NET 6 runtime installed. And with [.NET 6 reaching end of support November 12, 2024](https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/), it is probably a good idea to upgrade to .NET 8 which is the current LTS.

In order to load the DLLs for the correct framework, you have to supply the `-f` parameter on your commandline (e.g. in `tstypegen.targets`). See https://github.com/avensia-oss/tstypegen/pull/23